### PR TITLE
prettier ingnore .next, apply prettier on remaining files

### DIFF
--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,2 @@
+.next
+node_modules

--- a/web/pages/api/users/jam-sessions/[jamSessionId]/consult.js
+++ b/web/pages/api/users/jam-sessions/[jamSessionId]/consult.js
@@ -78,11 +78,9 @@ const get = async (req, res) => {
   })
 
   if (!userOnJamSession) {
-    res
-      .status(403)
-      .json({
-        message: 'You are not allowed to access this collections session',
-      })
+    res.status(403).json({
+      message: 'You are not allowed to access this collections session',
+    })
     return
   }
   res.status(200).json(userOnJamSession.jamSession)


### PR DESCRIPTION
Previous Prettier config did not exclude .next and nodemodules folder. Adding .prettierignore
It is not enough to run a single "npm run format" to update the whole project,  it seems it is limited to 200 files. 
Running prettier and making sure the entire project has been updated.