### PR TITLE
Fix ESLint flat config for Next.js

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -11,19 +11,20 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
     baseDirectory: __dirname,
     recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+    allConfig: js.configs.all,
 });
 
-export default defineConfig([{
-    extends: compat.extends("next/core-web-vitals"),
+export default defineConfig([
+    ...compat.extends("next/core-web-vitals", "prettier"),
+    {
+        plugins: {
+            header,
+            "unused-imports": unusedImports,
+        },
 
-    plugins: {
-        header,
-        "unused-imports": unusedImports,
+        rules: {
+            "header/header": [2, "license.js"],
+            "unused-imports/no-unused-imports": "error",
+        },
     },
-
-    rules: {
-        "header/header": [2, "license.js"],
-        "unused-imports/no-unused-imports": "error",
-    },
-}]);
+]);


### PR DESCRIPTION
## Summary
- convert the flat config to spread the Next.js and Prettier compatibility layers generated by `FlatCompat`
- keep the custom license header and unused import rules active under the ESLint 9 configuration

## Testing
- npm run lint *(fails in container: local registry only provides ESLint 8.x, so `eslint/config` cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68f7560549bc8325b7395cd4d986bb65