### PR TITLE
Add eslint-config-prettier dependency for ESLint 9 flat config

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -11,19 +11,20 @@ const __dirname = path.dirname(__filename);
 const compat = new FlatCompat({
     baseDirectory: __dirname,
     recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+    allConfig: js.configs.all,
 });
 
-export default defineConfig([{
-    extends: compat.extends("next/core-web-vitals"),
+export default defineConfig([
+    ...compat.extends("next/core-web-vitals", "prettier"),
+    {
+        plugins: {
+            header,
+            "unused-imports": unusedImports,
+        },
 
-    plugins: {
-        header,
-        "unused-imports": unusedImports,
+        rules: {
+            "header/header": [2, "license.js"],
+            "unused-imports/no-unused-imports": "error",
+        },
     },
-
-    rules: {
-        "header/header": [2, "license.js"],
-        "unused-imports/no-unused-imports": "error",
-    },
-}]);
+]);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -69,7 +69,8 @@
         "prettier": "^3.2.5",
         "prisma": "^5.14.0",
         "typescript": "^5.4.5",
-        "vitest": "3.0.7"
+        "vitest": "3.0.7",
+        "eslint-config-prettier": "^9.1.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -18486,6 +18487,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     }
   }

--- a/web/package.json
+++ b/web/package.json
@@ -91,7 +91,8 @@
     "prettier": "^3.2.5",
     "prisma": "^5.14.0",
     "typescript": "^5.4.5",
-    "vitest": "3.0.7"
+    "vitest": "3.0.7",
+    "eslint-config-prettier": "^9.1.2"
   },
   "override-comments": {
     "cookie": "Latest next-auth@4.24.11 depends on cookie@0.6.1 which has a security vulnerability"


### PR DESCRIPTION
## Summary
- add eslint-config-prettier to the devDependencies so the flat config can load the Prettier compatibility layer under ESLint 9
- record the dependency in package-lock.json for reproducible installs

## Testing
- npm run lint *(fails in container: the cached node_modules tree still has ESLint 8.57.1, which does not export `eslint/config`; reinstalling dependencies will upgrade ESLint to 9.x and allow the command to run)*

------
https://chatgpt.com/codex/tasks/task_e_68f7560549bc8325b7395cd4d986bb65