### PR TITLE
Fix stale student code in grading when switching participants

### DIFF
--- a/web/components/evaluations/grading/annotation/StudentFileAnnotationWrapper.js
+++ b/web/components/evaluations/grading/annotation/StudentFileAnnotationWrapper.js
@@ -127,7 +127,7 @@ const StudentFileAnnotationWrapper = ({ file: original }) => {
     syncRenderedValue,
   } = useCtrlState(
     annotation?.content ?? original.content,
-    `${original.path}:${discardVersion}`,
+    `${original.id ?? original.path}:${discardVersion}`,
   )
 
   // Snapshot: pull server content into the editor only when the annotation ID


### PR DESCRIPTION
The editable code-writing file editor in the grading view kept the previous student's content when switching participants. StudentFileAnnotationWrapper keyed useCtrlState on the file path, which is identical across students for the same question, so the reset effect never fired.

Key on the per-student-unique file id (path fallback), matching FileEditor's convention. Other answer-compare types were audited and already reset correctly (effect-on-prop, student-id remount key, or query.id key).