### PR TITLE
Fix stale annotated code in grading when switching participants

### DIFF
--- a/web/components/answer/CompareCode.js
+++ b/web/components/answer/CompareCode.js
@@ -108,7 +108,7 @@ const CompareCodeWriting = ({
                         (answerToFile.studentPermission ===
                           StudentPermission.UPDATE && (
                           <AnnotationProvider
-                            key={index}
+                            key={answerToFile.file.id ?? index}
                             annotation={answerToFile.file.annotation}
                             readOnly={readOnly}
                             student={student}

--- a/web/components/answer/ConsultCode.js
+++ b/web/components/answer/ConsultCode.js
@@ -78,7 +78,7 @@ const ConsultCodeWriting = ({ answer }) => {
             <ScrollContainer mt={1} px={1} spacing={1}>
               {files.map((answerToFile, index) => (
                 <AnnotationProvider
-                  key={index}
+                  key={answerToFile.file.id ?? index}
                   readOnly
                   annotation={answerToFile.file.annotation}
                   entityType={AnnotationEntityType.CODE_WRITING_FILE}


### PR DESCRIPTION
Keying the AnnotationProvider subtree by file index reused the same component instances across students. The annotation from AnnotationContext updates one effect-tick after the new file prop, so on the first render after navigation the wrapper held the previous student's annotation with the new student's file. useCtrlState's reset (keyed on file id since #669) then snapshotted the previous student's annotated content into the new student's editor, and never self-corrected.

Key the provider subtree on the per-student-unique file id so it remounts on student switch and initializes cleanly from the student's own content. File id is stable within a session, preserving the #669 cursor-jump fix.