### PR TITLE
Pin npm major in Docker images (deploy broken by npm@12 release)

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -32,7 +32,8 @@ RUN apt-get update && \
 
 # Install Node.js dependencies
 RUN npm cache clean --force
-RUN npm install -g npm@latest
+# npm major pinned: npm@12+ requires Node >=22, the image runs Node 20
+RUN npm install -g npm@11
 RUN rm -rf node_modules package-lock.json
 RUN npm install
 

--- a/web/Dockerfile.dev
+++ b/web/Dockerfile.dev
@@ -25,7 +25,8 @@ WORKDIR /app
 # Install Node.js dependencies
 COPY package*.json ./
 RUN npm cache clean --force
-RUN npm install -g npm@latest
+# npm major pinned: newer npm majors do not support the image's Node version
+RUN npm install -g npm@9
 RUN npm install --loglevel verbose
 
 # Copy the app's source code


### PR DESCRIPTION
## Problem

The PROD-SI deploy fails at `RUN npm install -g npm@latest`:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

npm published v12, which dropped Node 20 support, so `npm@latest` no longer installs on the `node:20-bullseye-slim` image. Nothing in our code changed — the moving `latest` target broke under us.

## Fix

Pin the npm major to one compatible with each image's Node version:

- `web/Dockerfile` (Node 20): `npm@11`
- `web/Dockerfile.dev` (Node 14): `npm@9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
