### PR TITLE
Truthful start-over warning: distinguish archived from deleted questions

### DIFF
--- a/web/components/evaluations/list/AddEvaluationDialog.js
+++ b/web/components/evaluations/list/AddEvaluationDialog.js
@@ -24,6 +24,7 @@ import CardSelector from '@/components/input/CardSelector'
 import {
   EvaluationPhase,
   QuestionSource,
+  QuestionStatus,
   UserOnEvaluationAccessMode,
 } from '@prisma/client'
 import useSWR from 'swr'
@@ -219,11 +220,22 @@ const EvaluationSummary = ({ groupScope, evaluationId }) => {
 
   const hasQuestions = Boolean(composition?.length)
 
-  const countMissingQuestions = composition?.filter(
-    (q) =>
-      afterComposition &&
-      q.question?.source === QuestionSource.EVAL &&
-      !q.question.sourceQuestion,
+  // After composition the evaluation holds copies (source = EVAL) linked to
+  // their bank original via sourceQuestion. Distinguish three states:
+  // active original, archived original (still in the bank), and untraceable
+  // (original deleted, or the evaluation predates question linking).
+  const evalQuestions = afterComposition
+    ? (composition ?? []).filter(
+        (q) => q.question?.source === QuestionSource.EVAL,
+      )
+    : []
+
+  const countArchivedQuestions = evalQuestions.filter(
+    (q) => q.question.sourceQuestion?.status === QuestionStatus.ARCHIVED,
+  ).length
+
+  const countUntraceableQuestions = evalQuestions.filter(
+    (q) => !q.question.sourceQuestion,
   ).length
 
   const hasAccessList =
@@ -249,14 +261,22 @@ const EvaluationSummary = ({ groupScope, evaluationId }) => {
         </Typography>
       )}
 
-      {countMissingQuestions > 0 && (
+      {countArchivedQuestions > 0 && (
         <Typography variant="body2" color={'error'}>
-          <b>{countMissingQuestions} questions</b> used in this evaluation no
-          longer exist in the question bank
+          <b>{countArchivedQuestions} questions</b> are archived in the question
+          bank — they will not be included when starting over
         </Typography>
       )}
 
-      {countMissingQuestions === 0 && (
+      {countUntraceableQuestions > 0 && (
+        <Typography variant="body2" color={'error'}>
+          <b>{countUntraceableQuestions} questions</b> could not be matched to a
+          question in the bank (deleted, or the evaluation predates question
+          linking) — they will not be included when starting over
+        </Typography>
+      )}
+
+      {countArchivedQuestions === 0 && countUntraceableQuestions === 0 && (
         <Typography variant="body2" color={'info'}>
           All questions are still available in the question bank
         </Typography>

--- a/web/components/evaluations/list/AddEvaluationDialog.js
+++ b/web/components/evaluations/list/AddEvaluationDialog.js
@@ -22,14 +22,12 @@ import DialogFeedback from '@/components/feedback/DialogFeedback'
 import { useEffect, useState } from 'react'
 import CardSelector from '@/components/input/CardSelector'
 import {
-  EvaluationPhase,
   QuestionSource,
   QuestionStatus,
   UserOnEvaluationAccessMode,
 } from '@prisma/client'
 import useSWR from 'swr'
 import { fetcher } from '@/core/utils'
-import { phaseGT } from '@/core/phase'
 import UserHelpPopper from '@/components/feedback/UserHelpPopper'
 
 const Presets = [
@@ -213,29 +211,24 @@ const EvaluationSummary = ({ groupScope, evaluationId }) => {
   // Check if evaluation exists
   if (!evaluation) return null
 
-  const afterComposition = phaseGT(
-    evaluation.phase,
-    EvaluationPhase.COMPOSITION,
-  )
-
   const hasQuestions = Boolean(composition?.length)
 
-  // After composition the evaluation holds copies (source = EVAL) linked to
-  // their bank original via sourceQuestion. Distinguish three states:
-  // active original, archived original (still in the bank), and untraceable
-  // (original deleted, or the evaluation predates question linking).
-  const evalQuestions = afterComposition
-    ? (composition ?? []).filter(
-        (q) => q.question?.source === QuestionSource.EVAL,
-      )
-    : []
+  // Draft evaluations reference bank questions directly (source = BANK,
+  // own status); after composition they hold copies (source = EVAL) linked
+  // to their bank original via sourceQuestion. Distinguish three states:
+  // active, archived (still in the bank), and untraceable (original
+  // deleted, or the evaluation predates question linking).
+  const questionsInComposition = composition ?? []
 
-  const countArchivedQuestions = evalQuestions.filter(
-    (q) => q.question.sourceQuestion?.status === QuestionStatus.ARCHIVED,
+  const countArchivedQuestions = questionsInComposition.filter((q) =>
+    q.question?.source === QuestionSource.EVAL
+      ? q.question.sourceQuestion?.status === QuestionStatus.ARCHIVED
+      : q.question?.status === QuestionStatus.ARCHIVED,
   ).length
 
-  const countUntraceableQuestions = evalQuestions.filter(
-    (q) => !q.question.sourceQuestion,
+  const countUntraceableQuestions = questionsInComposition.filter(
+    (q) =>
+      q.question?.source === QuestionSource.EVAL && !q.question.sourceQuestion,
   ).length
 
   const hasAccessList =

--- a/web/pages/api/[groupScope]/evaluations/[evaluationId]/composition/index.ts
+++ b/web/pages/api/[groupScope]/evaluations/[evaluationId]/composition/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { QuestionStatus, Role, Prisma } from '@prisma/client'
+import { Role, Prisma } from '@prisma/client'
 import {
   withAuthorization,
   withGroupScope,
@@ -67,10 +67,13 @@ const get = async (
           question: {
             select: {
               ...SELECT_FOR_PROFESSOR_LISTING,
+              // Unfiltered on purpose: consumers must distinguish an
+              // archived source (still in the bank) from a deleted one
+              // (sourceQuestion null) instead of conflating them.
               sourceQuestion: {
-                // Only Active
-                where: {
-                  status: QuestionStatus.ACTIVE,
+                select: {
+                  id: true,
+                  status: true,
                 },
               },
             },

--- a/web/pages/api/[groupScope]/evaluations/[evaluationId]/composition/index.ts
+++ b/web/pages/api/[groupScope]/evaluations/[evaluationId]/composition/index.ts
@@ -67,6 +67,7 @@ const get = async (
           question: {
             select: {
               ...SELECT_FOR_PROFESSOR_LISTING,
+              source: true,
               // Unfiltered on purpose: consumers must distinguish an
               // archived source (still in the bank) from a deleted one
               // (sourceQuestion null) instead of conflating them.


### PR DESCRIPTION
## Problem

Closes #457 — also addresses the first half of #460.

The start-over-from-template dialog warned that questions "no longer exist in the question bank" in cases where that was untrue:

1. **Archived ≠ deleted**: the composition endpoint fetched `sourceQuestion` filtered to `status: ACTIVE`, so an archived bank original came back as `null` — indistinguishable from a deleted one. Archiving questions after an exam is routine, so reusing a past exam showed the false warning for every archived question.
2. **Pre-linking evaluations**: question copies created before the `sourceQuestion` linkage existed have no source link, so the dialog claimed all their questions were missing even when the originals are alive and active.

## Fix

- The composition endpoint returns `sourceQuestion { id, status }` unfiltered — consumers can now distinguish an archived source from a deleted one.
- The dialog reports three states honestly:
  - **N questions are archived in the question bank — they will not be included when starting over** (matches the actual copy behavior, which skips archived sources)
  - **N questions could not be matched to a question in the bank (deleted, or the evaluation predates question linking) — they will not be included when starting over**
  - "All questions are still available" only when neither applies

Start-over copy behavior is unchanged (option A from the issue triage — warning truthfulness only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
