### PR TITLE
Refresh all tag selectors when question tags are edited

### DIFF
--- a/web/components/question/tags/QuestionTagsSelector.js
+++ b/web/components/question/tags/QuestionTagsSelector.js
@@ -39,7 +39,9 @@ const QuestionTagsSelector = ({ groupScope, questionId, size, onChange }) => {
   const onTagsChange = useCallback(
     async (newTags) => {
       await upsert(questionId, newTags)
-      await mutate(newTags)
+      // Revalidate: the GET shape is questionToTag rows ({ tag, label }),
+      // not the plain label strings we hold here.
+      await mutate()
       onChange && onChange(newTags)
     },
     [questionId, mutate, upsert, onChange],

--- a/web/context/TagContext.js
+++ b/web/context/TagContext.js
@@ -15,7 +15,7 @@
  */
 
 import React, { createContext, useContext, useCallback, useEffect } from 'react'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { Role } from '@prisma/client'
 import { useSession } from 'next-auth/react'
 import { fetcher } from '../core/utils'
@@ -35,6 +35,8 @@ export const TagsProvider = ({ children }) => {
   const { groupScope } = router.query
 
   const { data: session } = useSession()
+
+  const { mutate: globalMutate } = useSWRConfig()
 
   const {
     data: tags,
@@ -56,7 +58,7 @@ export const TagsProvider = ({ children }) => {
 
   const upsert = useCallback(
     async (questionId, tags) => {
-      return await fetch(`/api/${groupScope}/questions/${questionId}/tags`, {
+      await fetch(`/api/${groupScope}/questions/${questionId}/tags`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -66,12 +68,17 @@ export const TagsProvider = ({ children }) => {
           tags,
         }),
       })
-        .then((res) => res.json())
-        .then(async (updated) => {
-          await mutate(updated)
-        })
+      // Revalidate every tag-related key: the group tag list (this context)
+      // and all filter-side TagsSelector keys (same path with query params).
+      // Never write the PUT response into the cache - it is a raw Prisma
+      // transaction result, not a tag list.
+      await globalMutate(
+        (key) =>
+          typeof key === 'string' &&
+          key.startsWith(`/api/${groupScope}/questions/tags`),
+      )
     },
-    [groupScope, mutate],
+    [groupScope, globalMutate],
   )
 
   return (


### PR DESCRIPTION
## Problem

Closes #588

Editing a question's tags did not refresh tag selectors elsewhere, and worse:

1. **Stale filter suggestions**: the tag-edit path only touched the param-less `/questions/tags` SWR key, while filter-side `TagsSelector` instances fetch `/questions/tags?<filters>` — different keys, so their suggestions stayed stale until a window refocus or reload.
2. **Cache corruption**: the tags PUT endpoint returns a raw Prisma transaction result (an array of batch counts, tag rows and link rows). `TagContext.upsert` wrote that straight into the group tag list cache — after every tag edit, `allTags` was garbage until the next revalidation.
3. **Wrong-shaped optimistic write**: `QuestionTagsSelector` primed its question-tags cache with plain label strings while the GET shape is `questionToTag` rows — briefly rendering empty chips.

## Fix

- `TagContext.upsert` no longer writes any response body into a cache. After the PUT it revalidates **every** tag-related key via SWR's key-prefix global mutate (`key.startsWith('/api/{group}/questions/tags')`) — refreshing the context list and all filter-side selectors in one shot.
- `QuestionTagsSelector` revalidates instead of the wrong-shaped optimistic write.
- API untouched (its response body is now unused).

## Test

Edit tags on a question (add a brand-new tag, remove one), then check without reloading: the tag filter panel in the question list offers the new tag and drops fully-unused ones; the tag editor's autocomplete options stay intact (no undefined entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
