### PR TITLE
fix: refresh all tag selectors when question tags are edited (#588)

### DIFF
--- a/web/components/question/tags/QuestionTagsSelector.js
+++ b/web/components/question/tags/QuestionTagsSelector.js
@@ -39,7 +39,9 @@ const QuestionTagsSelector = ({ groupScope, questionId, size, onChange }) => {
   const onTagsChange = useCallback(
     async (newTags) => {
       await upsert(questionId, newTags)
-      await mutate(newTags)
+      // Revalidate: the GET shape is questionToTag rows ({ tag, label }),
+      // not the plain label strings we hold here.
+      await mutate()
       onChange && onChange(newTags)
     },
     [questionId, mutate, upsert, onChange],

--- a/web/context/TagContext.js
+++ b/web/context/TagContext.js
@@ -15,7 +15,7 @@
  */
 
 import React, { createContext, useContext, useCallback, useEffect } from 'react'
-import useSWR from 'swr'
+import useSWR, { useSWRConfig } from 'swr'
 import { Role } from '@prisma/client'
 import { useSession } from 'next-auth/react'
 import { fetcher } from '../core/utils'
@@ -35,6 +35,8 @@ export const TagsProvider = ({ children }) => {
   const { groupScope } = router.query
 
   const { data: session } = useSession()
+
+  const { mutate: globalMutate } = useSWRConfig()
 
   const {
     data: tags,
@@ -56,7 +58,7 @@ export const TagsProvider = ({ children }) => {
 
   const upsert = useCallback(
     async (questionId, tags) => {
-      return await fetch(`/api/${groupScope}/questions/${questionId}/tags`, {
+      await fetch(`/api/${groupScope}/questions/${questionId}/tags`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
@@ -66,12 +68,17 @@ export const TagsProvider = ({ children }) => {
           tags,
         }),
       })
-        .then((res) => res.json())
-        .then(async (updated) => {
-          await mutate(updated)
-        })
+      // Revalidate every tag-related key: the group tag list (this context)
+      // and all filter-side TagsSelector keys (same path with query params).
+      // Never write the PUT response into the cache - it is a raw Prisma
+      // transaction result, not a tag list.
+      await globalMutate(
+        (key) =>
+          typeof key === 'string' &&
+          key.startsWith(`/api/${groupScope}/questions/tags`),
+      )
     },
-    [groupScope, mutate],
+    [groupScope, globalMutate],
   )
 
   return (


### PR DESCRIPTION
Editing tags only touched the param-less group tag key, so filter-side TagsSelector instances (keyed with query params) stayed stale. Worse, the PUT response - a raw Prisma transaction result - was written into the group tag cache, corrupting it until the next revalidation, and the question-tag cache was primed with wrong-shaped label strings. Upsert now revalidates every tag key via a key-prefix global mutate and no response body is written into any cache.

Closes #588