### PR TITLE
Sanitize KaTeX-rendered HTML before injection

### DIFF
--- a/web/components/input/markdown/KatexBloc.js
+++ b/web/components/input/markdown/KatexBloc.js
@@ -15,6 +15,7 @@
  */
 
 import katex from 'katex'
+import DOMPurify from 'dompurify'
 import 'katex/dist/katex.min.css'
 
 const KatexBloc = ({ code }) => {
@@ -23,7 +24,9 @@ const KatexBloc = ({ code }) => {
       throwOnError: false,
       displayMode: true,
     })
-    return <span dangerouslySetInnerHTML={{ __html: html }} />
+    return (
+      <span dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }} />
+    )
   } catch (error) {
     return <span>{error.message}</span>
   }

--- a/web/components/input/markdown/previewOptions.js
+++ b/web/components/input/markdown/previewOptions.js
@@ -17,6 +17,7 @@
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import { getCodeString } from 'rehype-rewrite'
 import katex from 'katex'
+import DOMPurify from 'dompurify'
 import 'katex/dist/katex.min.css'
 import CodeBlock from './CodeBlock' // Use existing component for handling code blocks
 import MermaidBloc from './MermaidBloc' // Use existing component for handling Mermaid diagrams
@@ -50,7 +51,11 @@ export const previewOptions = {
               throwOnError: false,
             },
           )
-          return <code dangerouslySetInnerHTML={{ __html: html }} />
+          return (
+            <code
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
+            />
+          )
         }
         return <code>{txt}</code> // Inline code
       } else {
@@ -60,7 +65,11 @@ export const previewOptions = {
           const html = katex.renderToString(code, {
             throwOnError: false,
           })
-          return <code dangerouslySetInnerHTML={{ __html: html }} />
+          return (
+            <code
+              dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(html) }}
+            />
+          )
         } else if (language === 'mermaid') {
           return <MermaidBloc code={code} />
         } else if (language === 'graphviz') {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "online-test",
+  "name": "opendidac",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "online-test",
+      "name": "opendidac",
       "version": "0.1.0",
       "dependencies": {
         "@auth/prisma-adapter": "^2.11.0",
@@ -24,6 +24,7 @@
         "clipboard-copy": "^4.0.1",
         "date-fns": "^4.1.0",
         "dockerode": "^4.0.2",
+        "dompurify": "^3.3.0",
         "handlebars": "^4.7.8",
         "htmlspecialchars": "^1.0.5",
         "javascript-time-ago": "^2.5.9",

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "clipboard-copy": "^4.0.1",
     "date-fns": "^4.1.0",
     "dockerode": "^4.0.2",
+    "dompurify": "^3.3.0",
     "handlebars": "^4.7.8",
     "htmlspecialchars": "^1.0.5",
     "javascript-time-ago": "^2.5.9",


### PR DESCRIPTION
## Summary
- `katex.renderToString()` output was injected via `dangerouslySetInnerHTML` without sanitization in `previewOptions.js` (inline + block math in markdown preview) and `KatexBloc.js`
- Wraps both call sites with DOMPurify, as defense-in-depth alongside KaTeX's existing `trust: false` default (which already blocks the known injection vectors like `\href`, `\includegraphics`, `\htmlData`)
- Adds `dompurify` as a proper direct dependency (it was previously only pinned under `overrides` for a transitive package, not meant for direct import)

Closes #259

## Test plan
- [x] `npm run check` (Prettier) — clean
- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] Manually verified KaTeX rendering (fractions, sqrt, matrices, stretchy delimiters) still renders correctly in: question statement editor, student essay answer, grading view
- [x] Manually tested known KaTeX injection vectors (`\href{javascript:...}`, `\includegraphics{javascript:...}`, `\htmlData{onmouseover=...}`) — no script execution, no live handlers/links produced